### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -13,6 +13,9 @@ on:
             - 'v[0-9]+.[0-9]+.[0-9]+-**'
     pull_request: {}
 
+permissions:
+    contents: read
+
 # Cancel previous PR/branch runs when a new commit is pushed
 concurrency:
     group: ${{ github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/SentiQ/ioBroker.hydrawise/security/code-scanning/5](https://github.com/SentiQ/ioBroker.hydrawise/security/code-scanning/5)

Add an explicit top-level `permissions` block to the workflow so all jobs default to least privilege, while keeping the existing `deploy` job-level override (`contents: write`, `id-token: write`) unchanged.

Best fix here:
- Edit `.github/workflows/test-and-release.yml`.
- Insert at workflow root (after `on:` block, before `concurrency:`) a minimal read-only permission set:
  - `contents: read`
- Keep `deploy.permissions` as-is so release publishing continues to work.
- No imports, methods, or dependencies are needed.

This preserves behavior:
- `check-and-lint` and `adapter-tests` get explicit read-only token access.
- `deploy` still gets elevated write permissions only where required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
